### PR TITLE
Be explicit about opcode constants

### DIFF
--- a/elisp-bytecode.texi
+++ b/elisp-bytecode.texi
@@ -153,91 +153,220 @@ Make a binding recording buffer, point, and mark.
 
 @multitable @columnfractions .06 .30 .55
 @item Code @tab Instruction @tab Description
-@item 00
+@item 000
 @tab Not used; see @code{dup}
 @tab
-@item 01
+@item 001
 @tab @code{byte-stack-ref 1}
 @tab stack reference 1
-@item 02
+@item 002
 @tab @code{byte-stack-ref 2}
 @tab stack reference 2
-@item 03
+@item 003
 @tab @code{byte-stack-ref 3}
 @tab stack reference 3
-@item 04
+@item 004
 @tab @code{byte-stack-ref 4}
 @tab stack reference 4
-@item 05
+@item 005
 @tab @code{byte-stack-ref 5}
 @tab stack reference 5
-@item 06
+@item 006
 @tab @code{byte-stack-ref 6}
 @tab stack reference 0--255
-@item 07
+@item 007
 @tab @code{byte-stack-ref 7}
 @tab stack reference 0--65535
-@item 08
+@item 008
 @tab @code{byte-varref 0}
 @tab variable reference 0
-@item 09
+@item 009
 @tab @code{byte-varref 1}
 @tab variable reference 1
-@item 10
+@item 010
 @tab @code{byte-varref 2}
 @tab variable reference 2
-@item 11
+@item 011
 @tab @code{byte-varref 3}
 @tab variable reference 3
-@item 12
+@item 012
 @tab @code{byte-varref 4}
 @tab variable reference 4
-@item 13
+@item 013
 @tab @code{byte-varref 5}
 @tab variable reference 5
-@item 14
+@item 014
 @tab @code{byte-varref 6}
 @tab variable reference 0--255
-@item 15
+@item 015
 @tab @code{byte-varref 7}
 @tab variable reference 0--65535
-@item 16
+@item 016
 @tab @code{byte-varset 0}
 @tab Sets a variable
-@item 17
+@item 017
 @tab @code{byte-varset 1}
 @tab Sets a variable
-@item 18
+@item 018
 @tab @code{byte-varset 2}
 @tab Sets a variable
-@item 19
+@item 019
 @tab @code{byte-varset 3}
 @tab Sets a variable
-@item 20
+@item 020
 @tab @code{byte-varset 4}
 @tab Sets a variable
-@item 21
+@item 021
 @tab @code{byte-varset 5}
 @tab Sets a variable
-@item 22
+@item 022
 @tab @code{byte-varset 6}
 @tab Sets a variable
-@item 23
+@item 023
 @tab @code{byte-varset 7}
 @tab Sets a variable
-@item 24
+@item 024
 @tab @code{byte-varbind}
 @tab Binds a variable
-@item 32
+@item 032
 @tab @code{byte-call}
 @tab Calls a function
-@item 40
+@item 040
 @tab @code{byte-unbind}
 @tab Unbinds special bindings
-@item 192
+@item 129
 @tab @code{byte-constant}
-@tab Constant reference
+@tab Load a constant 0--65535 (but generally greater than 63)
+@item 192
+@tab @code{byte-constant 0}
+@item 193
+@tab @code{byte-constant 1}
+@item 194
+@tab @code{byte-constant 2}
+@item 195
+@tab @code{byte-constant 3}
+@item 196
+@tab @code{byte-constant 4}
+@item 197
+@tab @code{byte-constant 5}
+@item 198
+@tab @code{byte-constant 6}
+@item 199
+@tab @code{byte-constant 7}
+@item 200
+@tab @code{byte-constant 8}
+@item 201
+@tab @code{byte-constant 9}
+@item 202
+@tab @code{byte-constant 10}
+@item 203
+@tab @code{byte-constant 11}
+@item 204
+@tab @code{byte-constant 12}
+@item 205
+@tab @code{byte-constant 13}
+@item 206
+@tab @code{byte-constant 14}
+@item 207
+@tab @code{byte-constant 15}
+@item 208
+@tab @code{byte-constant 16}
+@item 209
+@tab @code{byte-constant 17}
+@item 210
+@tab @code{byte-constant 18}
+@item 211
+@tab @code{byte-constant 19}
+@item 212
+@tab @code{byte-constant 20}
+@item 213
+@tab @code{byte-constant 21}
+@item 214
+@tab @code{byte-constant 22}
+@item 215
+@tab @code{byte-constant 23}
+@item 216
+@tab @code{byte-constant 24}
+@item 217
+@tab @code{byte-constant 25}
+@item 218
+@tab @code{byte-constant 26}
+@item 219
+@tab @code{byte-constant 27}
+@item 220
+@tab @code{byte-constant 28}
+@item 221
+@tab @code{byte-constant 29}
+@item 222
+@tab @code{byte-constant 30}
+@item 223
+@tab @code{byte-constant 31}
+@item 224
+@tab @code{byte-constant 32}
+@item 225
+@tab @code{byte-constant 33}
+@item 226
+@tab @code{byte-constant 34}
+@item 227
+@tab @code{byte-constant 35}
+@item 228
+@tab @code{byte-constant 36}
+@item 229
+@tab @code{byte-constant 37}
+@item 230
+@tab @code{byte-constant 38}
+@item 231
+@tab @code{byte-constant 39}
+@item 232
+@tab @code{byte-constant 40}
+@item 233
+@tab @code{byte-constant 41}
+@item 234
+@tab @code{byte-constant 42}
+@item 235
+@tab @code{byte-constant 43}
+@item 236
+@tab @code{byte-constant 44}
+@item 237
+@tab @code{byte-constant 45}
+@item 238
+@tab @code{byte-constant 46}
+@item 239
+@tab @code{byte-constant 47}
+@item 240
+@tab @code{byte-constant 48}
+@item 241
+@tab @code{byte-constant 49}
+@item 242
+@tab @code{byte-constant 50}
+@item 243
+@tab @code{byte-constant 51}
+@item 244
+@tab @code{byte-constant 52}
+@item 245
+@tab @code{byte-constant 53}
+@item 246
+@tab @code{byte-constant 54}
+@item 247
+@tab @code{byte-constant 55}
+@item 248
+@tab @code{byte-constant 56}
+@item 249
+@tab @code{byte-constant 57}
+@item 250
+@tab @code{byte-constant 58}
+@item 251
+@tab @code{byte-constant 59}
+@item 252
+@tab @code{byte-constant 60}
+@item 253
+@tab @code{byte-constant 61}
+@item 254
+@tab @code{byte-constant 62}
+@item 255
+@tab @code{byte-constant 63}
 @end multitable
+
 
 @node References
 @chapter References


### PR DESCRIPTION
Be explicit about opcode instructions values. 

Possibly in the future the table will add a column for the code either in hex or octal, whichever is more helpful. 

Thoughts? 