### PR TITLE
WIP Control flow

### DIFF
--- a/instructions.texi
+++ b/instructions.texi
@@ -63,6 +63,8 @@ course there may be many constructs and there may be limiting
 situations within that construct. We'll only give one or a few of the
 constructs, and we'll try to indicate a limiting condition where
 possible.
+@item Instruction size:
+The number of bytes in the instruction. This is 1 to 3 bytes.
 @item Stack effect:
 This describes how many stack entries are read and popped and how many
 entries stack entries are pushed. Although this is logically a tuple,
@@ -305,7 +307,9 @@ Constants Vector: [n + 0 1 2 .. 61 62 63 64]
 
 @menu
 * goto::
+* goto-if-nil::
 * goto-if-not-nil::
+* goto-if-nil-else-pop::
 * goto-if-not-nil-else-pop::
 * return::
 @end menu
@@ -318,6 +322,8 @@ Constants Vector: [n + 0 1 2 .. 61 62 63 64]
 Jump to label given in the 16-bit operand
 @item Generated via:
 @code{while} and various control-flow constructs
+@item Instruction size:
+3 bytes
 @item Stack effect:
 @math{-0+0}
 @item Example:
@@ -338,18 +344,20 @@ Constants Vector: [n]
 @end verbatim
 @end table
 
-@node goto-if-not-nil
-@unnumberedsubsec @code{goto-if-not-nil} (131)
+@node goto-if-nil
+@unnumberedsubsec @code{goto-if-nil} (131)
 @kindex goto-if-not-nil
 @table @strong
 @item Implements:
-Jump to label given in the 16-bit operand if TOS is not nil
+Jump to label given in the 16-bit operand if TOS is nil
 @item Generated via:
 @code{if} with ``else'' clause and various control-flow constructs
+@item Instruction size:
+3 bytes
 @item Stack effect:
-@math{-0+0}
+@math{-1+0}
 @item Example:
-@code{(defun goto-if-not-nil-eg(n) (if (n) 2 3))} generates:
+@code{(defun goto-if-nil-eg(n) (if (n) 2 3))} generates:
 @verbatim
 PC  Byte  Instruction
  0  192   constant[0] n
@@ -368,8 +376,60 @@ Constants Vector: [n 2 3]
 @end verbatim
 @end table
 
+@node goto-if-not-nil
+@subsection @code{goto-if-not-nil} (132)
+@kindex goto-if-not-nil
+@table @strong
+@item Implements:
+Jump to label given in the 16-bit operand if TOS is not nil
+@item Generated via:
+@code{or} inside an @code{if} with optimization and various
+control-flow constructs
+@item Instruction size:
+3 bytes
+@item Stack effect:
+@math{-1+0}
+@item Example:
+@code{(defun goto-if-not-nil-eg(n) (if (or (n) (n)) 6))} generates
+@verbatim
+PC  Byte  Instruction
+ 0  192   constant[0] n
+ 1   32   call[0]
+ 2  134   goto-if-not-nil [10]
+           7
+           0
+ 5  192   constant[0] n
+ 6   32   call[0]
+ 7  133   goto-if-nil-else-pop [11]
+          11
+           0
+10  193   constant[1] 6
+11  135   return
+
+Constants Vector: [n 6]
+@end verbatim
+@end table
+
+@node goto-if-nil-else-pop
+@subsection @code{goto-if-nil-else-pop} (133)
+@kindex goto-if-not-else-pop
+@table @strong
+@item Implements:
+Jump to label given in the 16-bit operand if TOS is nil; otherwise
+pop the top stack instruction.
+@item Generated via:
+@code{cond}, @code{if} and various control-flow constructs
+@item Instruction size:
+3 bytes
+@item Stack effect:
+@math{\phi(0,-1)+0}
+@item Example:
+@verbatim
+@end verbatim
+@end table
+
 @node goto-if-not-nil-else-pop
-@unnumberedsubsec @code{goto-if-not-nil-else-pop} (133)
+@subsection @code{goto-if-not-nil-else-pop} (134)
 @kindex goto-if-not-nil-else-pop
 @table @strong
 @item Implements:
@@ -377,15 +437,17 @@ Jump to label given in the 16-bit operand if TOS is not nil; otherwise
 pop the top stack instruction.
 @item Generated via:
 @code{cond}, @code{if} and various control-flow constructs
+@item Instruction size:
+3 bytes
 @item Stack effect:
-@math{\phi(0,-1)}
+@math{\phi(0,-1)+0}
 @item Example:
 @code{(defun goto-if-not-nil-else-pop-eg(n) (if (n) 2))} generates:
 @verbatim
 PC  Byte  Instruction
  0  192   constant[0] n
  1   32   call[0]
- 2  133   goto-if-nil-else-pop [6]
+ 2  134   goto-if-nil-else-pop [6]
            6
            0
  5  193   constant[1] 2
@@ -393,7 +455,6 @@ PC  Byte  Instruction
 
 Constants Vector: [n 2]
 @end verbatim
-
 @end table
 
 @node return
@@ -405,6 +466,8 @@ Return from function.  This is the last instruction in a function's
 bytecode sequence. The top value on the evaluation stack is the return value.
 @item Generated via:
 @code{lambda}
+@item Instruction size:
+1 byte
 @item Stack effect:
 @math{-1+0}
 @item Example:
@@ -416,7 +479,6 @@ PC  Byte  Instruction
 
 Constants Vector: [1]
 @end verbatim
-
 @end table
 
 @node Function-Call Instructions
@@ -592,6 +654,8 @@ bytecode interpreter.
 @code{TOS <- (nth S[1] TOS)}.
 @item Generated via:
 binary @code{nth}.
+@item Instruction size:
+1 byte
 @item Stack effect:
 @math{-2+1}.
 @item Example:
@@ -616,6 +680,8 @@ Constants Vector: [5]
 @code{TOS <- (car TOS)}.
 @item Generated via:
 unary @code{car}.
+@item Instruction size:
+1 byte
 @item Stack effect:
 @math{-1+1}.
 @item Example:
@@ -637,6 +703,8 @@ PC  Byte  Instruction
 @code{TOS <- (cdr TOS)}.
 @item Generated via:
 unary @code{cdr}.
+@item Instruction size:
+1 byte
 @item Stack effect:
 @math{-1+1}.
 @item Example:
@@ -659,6 +727,8 @@ PC  Byte  Instruction
 @code{TOS <- (cons S[1] TOS)}.
 @item Generated via:
 binary @code{cons}.
+@item Instruction size:
+1 byte
 @item Stack effect:
 @math{-2+1}.
 @item Example:
@@ -808,6 +878,8 @@ bytecode interpreter.
 @code{TOS <- (1- TOS)}.
 @item Generated via:
 unary @code{1-}.
+@item Instruction size:
+1 byte
 @item Stack effect:
 @math{-1+1}.
 @item Example:
@@ -830,6 +902,8 @@ PC  Byte  Instruction
 @code{TOS <- (1+ TOS)}.
 @item Generated via:
 unary @code{-}.
+@item Instruction size:
+1 byte
 @item Stack effect:
 @math{-1+1}.
 @item Example:
@@ -852,6 +926,8 @@ PC  Byte  Instruction
 @code{TOS <- (= TOS S[1]}.
 @item Generated via:
 binary @code{=}.
+@item Instruction size:
+1 byte
 @item Stack effect:
 @math{-2+1}.
 @item Example:
@@ -877,6 +953,8 @@ Constants Vector: [a b]
 @code{TOS <- (> TOS S[1]}.
 @item Generated via:
 binary @code{>}.
+@item Instruction size:
+1 byte
 @item Stack effect:
 @math{-2+1}.
 @item Example:
@@ -900,6 +978,8 @@ PC  Byte  Instruction
 @code{TOS <- (< S[1] TOS}.
 @item Generated via:
 binary @code{<}.
+@item Instruction size:
+1 byte
 @item Stack effect:
 @math{-2+1}.
 @item Example:
@@ -923,8 +1003,12 @@ Constants Vector: [a b]
 @table @strong
 @item Implements:
 @code{TOS <- (<= S[1] TOS)}.
+@item Instruction size:
+1 byte
 @item Generated via:
 binary @code{<=}.
+@item Instruction size:
+1 byte
 @item Stack effect:
 @math{-2+1}.
 @item Example:
@@ -948,8 +1032,12 @@ Constants Vector: [a b]
 @table @strong
 @item Implements:
 @code{TOS <- (>= S[1] TOS}.
+@item Instruction size:
+1 byte
 @item Generated via:
 binary @code{>=}.
+@item Instruction size:
+1 byte
 @item Stack effect:
 @math{-2+1}.
 @item Example:
@@ -973,6 +1061,10 @@ PC  Byte  Instruction
 @code{TOS <- (- S[1] TOS}.
 @item Generated via:
 binary @code{-}.
+@item Instruction size:
+1 byte
+@item Instruction size:
+1 byte
 @item Stack effect:
 @math{-2+1}.
 @item Example:
@@ -996,6 +1088,10 @@ PC  Byte  Instruction
 @code{TOS <- (- TOS)}.
 @item Generated via:
 unary @code{-}.
+@item Instruction size:
+1 byte
+@item Instruction size:
+1 byte
 @item Stack effect:
 @math{-1+1}.
 @item Example:
@@ -1018,6 +1114,8 @@ PC  Byte  Instruction
 @code{TOS <- (+ S[1] TOS)}.
 @item Generated via:
 binary @code{+}.
+@item Instruction size:
+1 byte
 @item Stack effect:
 @math{-2+1}.
 @item Example:
@@ -1043,6 +1141,8 @@ Constants Vector: [n]
 @code{TOS <- (* S[1] TOS)}.
 @item Generated via:
 binary @code{*}.
+@item Instruction size:
+1 byte
 @item Stack effect:
 @math{-2+1}.
 @item Added in:
@@ -1070,6 +1170,8 @@ Constants Vector: [n]
 @code{TOS <- (max S[1] TOS)}.
 @item Generated via:
 binary @code{max}.
+@item Instruction size:
+1 byte
 @item Stack effect:
 @math{-2+1}.
 @item Example:
@@ -1095,6 +1197,8 @@ Constants Vector: [a b]
 @code{TOS <- (min(S[1] TOS)}.
 @item Generated via:
 binary @code{min}.
+@item Instruction size:
+1 byte
 @item Stack effect:
 @math{-2+1}.
 @item Example:
@@ -1120,6 +1224,8 @@ Constants Vector: [a b]
 @code{TOS <- (/ S[1] TOS)}.
 @item Generated via:
 binary @verb{|/|}.
+@item Instruction size:
+1 byte
 @item Stack effect:
 @math{-2+1}.
 @item Example:
@@ -1145,6 +1251,8 @@ Constants Vector: [a b]
 @code{TOS <- (\% S[1] TOS)}.
 @item generated via:
 binary @verb{|%|}
+@item Instruction size:
+1 byte
 @item Stack effect:
 @math{-2+1}
 @item Added in:

--- a/instructions.texi
+++ b/instructions.texi
@@ -462,7 +462,7 @@ again when the jump is taken.
 @item Stack effect:
 @math{\phi(0,-1)+0}
 @item Example:
-@code{(defun goto-if-not-nil-eg(n) (if (or (n) (n)) 1340))} generates:
+@code{(defun goto-if-not-nil-else-pop-eg(n) (if (or (n) (n)) 1340))} generates:
 @verbatim
 PC  Byte  Instruction
  0  192   constant[0] n

--- a/instructions.texi
+++ b/instructions.texi
@@ -327,7 +327,7 @@ Jump to label given in the 16-bit operand
 @item Stack effect:
 @math{-0+0}
 @item Example:
-@code{(defun goto-eg(n) (while (n) 2))} generates:
+@code{(defun goto-eg(n) (while (n) 1300))} generates:
 @verbatim
 PC  Byte  Instruction
  0  192   constant[0] n
@@ -342,6 +342,7 @@ PC  Byte  Instruction
 
 Constants Vector: [n]
 @end verbatim
+
 @end table
 
 @node goto-if-nil
@@ -349,7 +350,8 @@ Constants Vector: [n]
 @kindex goto-if-not-nil
 @table @strong
 @item Implements:
-Jump to label given in the 16-bit operand if TOS is nil
+Jump to label given in the 16-bit operand if TOS is nil. In contrast to
+@code{goto-if-nil-else-pop}, the test expression, TOS, is always popped.
 @item Generated via:
 @code{if} with ``else'' clause and various control-flow constructs
 @item Instruction size:
@@ -357,7 +359,7 @@ Jump to label given in the 16-bit operand if TOS is nil
 @item Stack effect:
 @math{-1+0}
 @item Example:
-@code{(defun goto-if-nil-eg(n) (if (n) 2 3))} generates:
+@code{(defun goto-if-nil-eg(n) (if (n) 1310 1311))} generates:
 @verbatim
 PC  Byte  Instruction
  0  192   constant[0] n
@@ -365,15 +367,16 @@ PC  Byte  Instruction
  2  131   goto-if-nil [9]
            9
            0
- 5  193   constant[1] 2
+ 5  193   constant[1] 1310
  6  130   goto [10]
           10
            0
- 9  194   constant[2] 3
+ 9  194   constant[2] 1311
 10  135   return
 
-Constants Vector: [n 2 3]
+Constants Vector: [n 1310 1311]
 @end verbatim
+
 @end table
 
 @node goto-if-not-nil
@@ -381,7 +384,9 @@ Constants Vector: [n 2 3]
 @kindex goto-if-not-nil
 @table @strong
 @item Implements:
-Jump to label given in the 16-bit operand if TOS is not nil
+Jump to label given in the 16-bit operand if TOS is not nil.  In
+contrast to @code{goto-if-not-nil-else-pop}, the test expression, TOS, is
+always popped.
 @item Generated via:
 @code{or} inside an @code{if} with optimization and various
 control-flow constructs
@@ -390,12 +395,12 @@ control-flow constructs
 @item Stack effect:
 @math{-1+0}
 @item Example:
-@code{(defun goto-if-not-nil-eg(n) (if (or (n) (n)) 6))} generates
+With bytecode optimization, @code{(defun goto-if-not-nil-eg(n) (if (or (n) (n)) 1320))} generates
 @verbatim
 PC  Byte  Instruction
  0  192   constant[0] n
  1   32   call[0]
- 2  134   goto-if-not-nil [10]
+ 2  132   goto-if-not-nil [10]
            7
            0
  5  192   constant[0] n
@@ -403,20 +408,23 @@ PC  Byte  Instruction
  7  133   goto-if-nil-else-pop [11]
           11
            0
-10  193   constant[1] 6
+10  193   constant[1] 1320
 11  135   return
 
-Constants Vector: [n 6]
+Constants Vector: [n 1320]
 @end verbatim
+
+Note the change in opcode when bytecode optimization is not performed.
 @end table
 
 @node goto-if-nil-else-pop
 @subsection @code{goto-if-nil-else-pop} (133)
-@kindex goto-if-not-else-pop
+@kindex goto-if-nil-else-pop
 @table @strong
 @item Implements:
-Jump to label given in the 16-bit operand if TOS is nil; otherwise
-pop the top stack instruction.
+Jump to label given in the 16-bit operand if TOS is nil; otherwise pop
+the TOS, the tested condition. This allows the test expression, nil,
+to be used again on the branch as the TOS.
 @item Generated via:
 @code{cond}, @code{if} and various control-flow constructs
 @item Instruction size:
@@ -424,7 +432,18 @@ pop the top stack instruction.
 @item Stack effect:
 @math{\phi(0,-1)+0}
 @item Example:
+@code{(defun goto-if-nil-else-pop-eg(n) (cond ((n) 1330)))} generates:
 @verbatim
+PC  Byte  Instruction
+ 0  192   constant[0] n
+ 1   32   call[0]
+ 2  133   goto-if-nil-else-pop [6]
+           6
+           0
+ 5  193   constant[1] 1330
+ 6  135   return
+
+Constants Vector: [n 1330]
 @end verbatim
 @end table
 
@@ -434,7 +453,8 @@ pop the top stack instruction.
 @table @strong
 @item Implements:
 Jump to label given in the 16-bit operand if TOS is not nil; otherwise
-pop the top stack instruction.
+pop TOS, the tested condition. This allows the tested expression on TOS to be used
+again when the jump is taken.
 @item Generated via:
 @code{cond}, @code{if} and various control-flow constructs
 @item Instruction size:
@@ -442,19 +462,26 @@ pop the top stack instruction.
 @item Stack effect:
 @math{\phi(0,-1)+0}
 @item Example:
-@code{(defun goto-if-not-nil-else-pop-eg(n) (if (n) 2))} generates:
+@code{(defun goto-if-not-nil-eg(n) (if (or (n) (n)) 1340))} generates:
 @verbatim
 PC  Byte  Instruction
  0  192   constant[0] n
  1   32   call[0]
- 2  134   goto-if-nil-else-pop [6]
-           6
+ 2  134   goto-if-not-nil-else-pop [7]
+           7
            0
- 5  193   constant[1] 2
- 6  135   return
+ 5  192   constant[0] n
+ 6   32   call[0]
+ 7  133   goto-if-nil-else-pop [11]
+          11
+           0
+10  193   constant[1] 1340
+11  135   return
 
-Constants Vector: [n 2]
+Constants Vector: [n 1340]
 @end verbatim
+
+Note the change in opcode when bytecode optimization is performed.
 @end table
 
 @node return
@@ -471,14 +498,15 @@ bytecode sequence. The top value on the evaluation stack is the return value.
 @item Stack effect:
 @math{-1+0}
 @item Example:
-@code{(defun return-eg(n) 1)} generates:
+@code{(defun return-eg(n) 1350)} generates:
 @verbatim
 PC  Byte  Instruction
- 0  192   constant[0] 1
+ 0  192   constant[0] 1350
  1  135   return
 
-Constants Vector: [1]
+Constants Vector: [1350]
 @end verbatim
+
 @end table
 
 @node Function-Call Instructions
@@ -659,15 +687,15 @@ binary @code{nth}.
 @item Stack effect:
 @math{-2+1}.
 @item Example:
-When lexical binding is in effect, @code{(defun nth-eg(l) (nth 5 l))} generates:
+When lexical binding is in effect, @code{(defun nth-eg(l) (nth 560 l))} generates:
 @verbatim
 PC  Byte  Instruction
- 0  192   constant[0] 5
+ 0  192   constant[0] 560
  1    1   stack-ref[1]
  2   56   nth
  3  135   return
 
-Constants Vector: [5]
+Constants Vector: [560]
 @end verbatim
 
 @end table

--- a/instructions.texi
+++ b/instructions.texi
@@ -1,14 +1,107 @@
 @node ELisp Bytecode Instructions
 @chapter ELisp Bytecode Instructions
 
+
 @menu
+* Instruction-Description Format::
 * Argument-Packing Instructions::
 * Constants-Vector Retrieval Instructions::
-* Return Instruction::
+* Control-Flow Instructions::
 * Function-Call Instructions::
 * Stack Manipulation Instructions::
 * Binding Instructions::
 @end menu
+
+@node Instruction-Description Format
+@section Instruction-Description Format
+
+In this chapter we'll document instructions of the course of the
+entire history of Emacs. (Or at least we aim to.)
+
+To simplify and regularize things we'll use a standard format and a
+small amount of jargon which is be explained here.
+
+@subsection Instruction Jargon
+@itemize
+@item @code{TOS}
+The top of the evaluations stack. Many instruction either read or push onto this
+@item @code{S}
+This is an array of evaluation stack items. @code{S[0]} is the top of the same or
+@code{TOS}.
+@item @math{\phi}
+This is used in describing stack effects for branching instructions
+where the stack effect is different on one branch versus the
+other. This is a function of two arguments. The first argument gives
+the stack effect on the non-nil branch and the second argument gives
+the stack effect for the nil branch. So @math{\phi(0,-1)} which is
+seen in @code{goto-if-not-nil-else-pop} means that if the jump is
+taken, the stack effect is 0, otherwise the effect removes or pops an
+evaluation-stack entry.
+@item opcode subscripting @code{[]})
+In many opcodes such as @code{constant}, @code{varref}, you will find
+an index after the opcode. What's going on is that opcode is one of a
+number of opcodes in a class encodes an index into the opcode. We
+generally call this an ``Argument-encoding'' instruction. In both the
+display of the opcode as well we'll include that particular opcode
+variant in subscripts.
+
+For example consider @code{constant[0]} versus @code{constant[1]}.
+The former has opcode 192 while the latter has opcode 193. In terms of
+semantics the former is the first or zeroth-index entry in a function's constant
+vector while the latter is the second or 1-index entry.
+
+@end itemize
+
+@subsection Instruction Description Fields
+The description of fields use for describing each instruction is as follows
+@table @strong
+@item Implements:
+A description of what the instruction does.
+@item Generated via:
+These give some ELisp constructs that may generate the instruction. Of
+course there may be many constructs and there may be limiting
+situations within that construct. We'll only give one or a few of the
+constructs, and we'll try to indicate a limiting condition where
+possible.
+@item Stack effect:
+This describes how many stack entries are read and popped and how many
+entries stack entries are pushed. Although this is logically a tuple,
+we'll list this a tuple like @math{(-3, 2)} as a single scalar
+@math{-3+2}. In this example, we read/remove three stack entries and
+add two.  The reason we give this as @math{-3+2} rather than the tuple
+format is so that the overall effect (removing a stack entry) can be
+seen by evaluating the expression.
+@item Added in:
+This is optiona. When it is given this gives which version of Emacs
+the opcode was added. It may also give when the opcode became obsolete
+or was no longer implemented.
+@item Example:
+Some ELisp code to show how the instruction is used. For example
+the for the @code{go} instruction we give:
+
+@code{(defun goto-eg(n) (while (n) 2))} generates:
+@verbatim
+PC  Byte  Instruction
+ 0  192   constant[0] n
+ 1   32   call[0]
+ 2  133   goto-if-nil-else-pop [8]
+           8
+           0
+ 5  130   goto [0]
+           0
+           0
+ 8  135   return
+
+Constants Vector: [n]
+@end verbatim
+
+From the above we see that the @code{goto} instruction at program
+counter (PC) 5, has decimal opcode 130. It the instruction is three bytes
+long.
+
+Unless otherwise stated, all code examples were compiled in Emacs 25
+with optimization turned off.
+@end table
 
 @node Argument-Packing Instructions
 @section Argument-Packing Instructions
@@ -206,16 +299,116 @@ PC  Byte  Instruction
 Constants Vector: [n + 0 1 2 .. 61 62 63 64]
 @end verbatim
 
-@node Return Instruction
-@section Return Instruction
+@page
+@node Control-Flow Instructions
+@section Control-Flow Instructions
 
+@menu
+* goto::
+* goto-if-not-nil::
+* goto-if-not-nil-else-pop::
+* return::
+@end menu
+
+@node goto
+@unnumberedsubsec @code{goto} (130)
+@kindex goto
+@table @strong
+@item Implements:
+Jump to label given in the 16-bit operand
+@item Generated via:
+@code{while} and various control-flow constructs
+@item Stack effect:
+@math{-0+0}
+@item Example:
+@code{(defun goto-eg(n) (while (n) 2))} generates:
+@verbatim
+PC  Byte  Instruction
+ 0  192   constant[0] n
+ 1   32   call[0]
+ 2  133   goto-if-nil-else-pop [8]
+           8
+           0
+ 5  130   goto [0]
+           0
+           0
+ 8  135   return
+
+Constants Vector: [n]
+@end verbatim
+@end table
+
+@node goto-if-not-nil
+@unnumberedsubsec @code{goto-if-not-nil} (131)
+@kindex goto-if-not-nil
+@table @strong
+@item Implements:
+Jump to label given in the 16-bit operand if TOS is not nil
+@item Generated via:
+@code{if} with ``else'' clause and various control-flow constructs
+@item Stack effect:
+@math{-0+0}
+@item Example:
+@code{(defun goto-if-not-nil-eg(n) (if (n) 2 3))} generates:
+@verbatim
+PC  Byte  Instruction
+ 0  192   constant[0] n
+ 1   32   call[0]
+ 2  131   goto-if-nil [9]
+           9
+           0
+ 5  193   constant[1] 2
+ 6  130   goto [10]
+          10
+           0
+ 9  194   constant[2] 3
+10  135   return
+
+Constants Vector: [n 2 3]
+@end verbatim
+@end table
+
+@node goto-if-not-nil-else-pop
+@unnumberedsubsec @code{goto-if-not-nil-else-pop} (133)
+@kindex goto-if-not-nil-else-pop
+@table @strong
+@item Implements:
+Jump to label given in the 16-bit operand if TOS is not nil; otherwise
+pop the top stack instruction.
+@item Generated via:
+@code{cond}, @code{if} and various control-flow constructs
+@item Stack effect:
+@math{\phi(0,-1)}
+@item Example:
+@code{(defun goto-if-not-nil-else-pop-eg(n) (if (n) 2))} generates:
+@verbatim
+PC  Byte  Instruction
+ 0  192   constant[0] n
+ 1   32   call[0]
+ 2  133   goto-if-nil-else-pop [6]
+           6
+           0
+ 5  193   constant[1] 2
+ 6  135   return
+
+Constants Vector: [n 2]
+@end verbatim
+
+@end table
+
+@node return
 @unnumberedsubsec @code{return} (135)
 @kindex return
+@table @strong
+@item Implements:
 Return from function.  This is the last instruction in a function's
 bytecode sequence. The top value on the evaluation stack is the return value.
-
-@subsubsection Example
-@code{(defun one(n) 1)} generates:
+@item Generated via:
+@code{lambda}
+@item Stack effect:
+@math{-1+0}
+@item Example:
+@code{(defun return-eg(n) 1)} generates:
 @verbatim
 PC  Byte  Instruction
  0  192   constant[0] 1
@@ -223,6 +416,8 @@ PC  Byte  Instruction
 
 Constants Vector: [1]
 @end verbatim
+
+@end table
 
 @node Function-Call Instructions
 @section Function-Call Instructions

--- a/instructions.texi
+++ b/instructions.texi
@@ -26,7 +26,7 @@ small amount of jargon which is be explained here.
 @item @code{TOS}
 The top of the evaluations stack. Many instruction either read or push onto this
 @item @code{S}
-This is an array of evaluation stack items. @code{S[0]} is the top of the same or
+This is an array of evaluation stack items. @code{S[0]} is the top of the stack, or
 @code{TOS}.
 @item @math{\phi}
 This is used in describing stack effects for branching instructions
@@ -37,7 +37,7 @@ the stack effect for the nil branch. So @math{\phi(0,-1)} which is
 seen in @code{goto-if-not-nil-else-pop} means that if the jump is
 taken, the stack effect is 0, otherwise the effect removes or pops an
 evaluation-stack entry.
-@item opcode subscripting @code{[]})
+@item opcode subscripting (@code{[]})
 In many opcodes such as @code{constant}, @code{varref}, you will find
 an index after the opcode. What's going on is that opcode is one of a
 number of opcodes in a class encodes an index into the opcode. We
@@ -77,7 +77,7 @@ the opcode was added. It may also give when the opcode became obsolete
 or was no longer implemented.
 @item Example:
 Some ELisp code to show how the instruction is used. For example
-the for the @code{go} instruction we give:
+the for the @code{goto} instruction we give:
 
 @code{(defun goto-eg(n) (while (n) 2))} generates:
 @verbatim
@@ -96,8 +96,8 @@ Constants Vector: [n]
 @end verbatim
 
 From the above we see that the @code{goto} instruction at program
-counter (PC) 5, has decimal opcode 130. It the instruction is three bytes
-long.
+counter (PC) 5, has decimal opcode 130. The instruction is three bytes
+long: a one-byte opcode followed by a two-byte operand.
 
 Unless otherwise stated, all code examples were compiled in Emacs 25
 with optimization turned off.

--- a/instructions.texi
+++ b/instructions.texi
@@ -41,13 +41,14 @@ evaluation-stack entry.
 In many opcodes such as @code{constant}, @code{varref}, you will find
 an index after the opcode. What's going on is that opcode is one of a
 number of opcodes in a class encodes an index into the opcode. We
-generally call this an ``Argument-encoding'' instruction. In both the
-display of the opcode as well we'll include that particular opcode
-variant in subscripts.
+generally call this an ``Argument-encoding'' instruction. In the
+display of the opcode in assembly listings and in the opcode table
+chapter where we list each opcode, we will include that particular
+opcode variant in subscripts.
 
 For example consider @code{constant[0]} versus @code{constant[1]}.
 The former has opcode 192 while the latter has opcode 193. In terms of
-semantics the former is the first or zeroth-index entry in a function's constant
+semantics, the former is the first or zeroth-index entry in a function's constant
 vector while the latter is the second or 1-index entry.
 
 @end itemize

--- a/opcode-table.texi
+++ b/opcode-table.texi
@@ -563,6 +563,11 @@ the stack-effect field.
 @tab @verb{|  current-column|}
 @tab Call @code{current-column} with no arguments.
 @tab @math{-0+1}
+@item @verb{|0153|}
+@tab @verb{|*107|}
+@tab @verb{|  scan-buffer|}
+@tab
+@tab
 @item @verb{|0154|}
 @tab @verb{| 108|}
 @tab @verb{|  eolp|}

--- a/opcode-table.texi
+++ b/opcode-table.texi
@@ -2,10 +2,9 @@
 @chapter Opcode Table
 
 In the table below, a @code{*} by the decimal number indicates an
-obsolete instruction. Stack effects are given as the number of
-stack entries popped followed by the number of entries pushed. For
-example, for a @code{cons} instruction, two stack entries are popped and
-one is pushed. This is denoted: @math{-2+1}.
+obsolete instruction. See @xref{Instruction-Description Format} for a
+description of how to interpret opcode when it has an index in it and
+the stack-effect field.
 
 @menu
 * Opcodes (0000-0077)::
@@ -685,9 +684,18 @@ one is pushed. This is denoted: @math{-2+1}.
 @item @verb{|0201|}
 @tab @verb{| 129|}
 @tab @verb{|  constant2|}
-@tab Load a constant 0--65535 (but generally greater than 63)
+@tab Load a constant 0--65535
 @tab @math{+1}
-
+@item @verb{|0205|}
+@tab @verb{| 133|}
+@tab @verb{|  goto-if-not-nil-else-pop|}
+@tab Jump if TOS is not nil, else pop
+@tab @math{-1+0}
+@item @verb{|0207|}
+@tab @verb{| 135|}
+@tab @verb{|  return|}
+@tab return from a function
+@tab @math{-1+0}
 @item @verb{|0210|}
 @tab @verb{| 136|}
 @tab @verb{|  discard|}

--- a/opcode-table.texi
+++ b/opcode-table.texi
@@ -2,9 +2,9 @@
 @chapter Opcode Table
 
 In the table below, a @code{*} by the decimal number indicates an
-obsolete instruction. See @xref{Instruction-Description Format} for a
-description of how to interpret opcode when it has an index in it and
-the stack-effect field.
+obsolete instruction. @xref{Instruction-Description Format} for a
+description of how to interpret opcode when it contans an index, for a description
+of how to interpret the stack-effect field.
 
 @menu
 * Opcodes (0000-0077)::

--- a/opcode-table.texi
+++ b/opcode-table.texi
@@ -694,14 +694,24 @@ the stack-effect field.
 @tab @math{-1+0}
 @item @verb{|0203|}
 @tab @verb{| 131|}
+@tab @verb{|  goto-if-nil|}
+@tab Jump if TOS is nil
+@tab @math{-1+0}
+@item @verb{|0204|}
+@tab @verb{| 132|}
 @tab @verb{|  goto-if-not-nil|}
 @tab Jump if TOS is not nil
 @tab @math{-1+0}
 @item @verb{|0205|}
 @tab @verb{| 133|}
+@tab @verb{|  goto-if-nil-else-pop|}
+@tab Jump if TOS is nil, else pop
+@tab @math{\phi(-1,0)+0}
+@item @verb{|0206|}
+@tab @verb{| 134|}
 @tab @verb{|  goto-if-not-nil-else-pop|}
 @tab Jump if TOS is not nil, else pop
-@tab @math{\phi(-1,+0)}
+@tab @math{\phi(-1,0)+0}
 @item @verb{|0207|}
 @tab @verb{| 135|}
 @tab @verb{|  return|}
@@ -711,17 +721,17 @@ the stack-effect field.
 @tab @verb{| 136|}
 @tab @verb{|  discard|}
 @tab Discard top stack value
-@tab @math{-1}
+@tab @math{-1+0}
 @item @verb{|0211|}
 @tab @verb{| 137|}
 @tab @verb{|  dup|}
 @tab Duplicate top stack value
-@tab @math{+1}
+@tab @math{-0+1}
 @item @verb{|0212|}
 @tab @verb{| 138|}
 @tab @verb{|  save-excursion|}
 @tab Make a binding recording buffer, point, and mark.
-@tab @math{-0}
+@tab @math{-0+0}
 
 @item @verb{|0257|}
 @tab @verb{| 175|}

--- a/opcode-table.texi
+++ b/opcode-table.texi
@@ -2,9 +2,10 @@
 @chapter Opcode Table
 
 In the table below, a @code{*} by the decimal number indicates an
-obsolete instruction. @xref{Instruction-Description Format} for a
-description of how to interpret opcode when it contans an index, for a description
-of how to interpret the stack-effect field.
+obsolete instruction. @xref{Instruction-Description Format} for
+abbreviations used here, a description of how to interpret an opcode
+when it contans an index, and for a description of how to interpret
+the stack-effect field.
 
 @menu
 * Opcodes (0000-0077)::
@@ -686,11 +687,21 @@ of how to interpret the stack-effect field.
 @tab @verb{|  constant2|}
 @tab Load a constant 0--65535
 @tab @math{+1}
+@item @verb{|0202|}
+@tab @verb{| 130|}
+@tab @verb{|  goto|}
+@tab Unconditional Jump
+@tab @math{-1+0}
+@item @verb{|0203|}
+@tab @verb{| 131|}
+@tab @verb{|  goto-if-not-nil|}
+@tab Jump if TOS is not nil
+@tab @math{-1+0}
 @item @verb{|0205|}
 @tab @verb{| 133|}
 @tab @verb{|  goto-if-not-nil-else-pop|}
 @tab Jump if TOS is not nil, else pop
-@tab @math{-1+0}
+@tab @math{\phi(-1,+0)}
 @item @verb{|0207|}
 @tab @verb{| 135|}
 @tab @verb{|  return|}


### PR DESCRIPTION
Probably need lingo to tell byte-recalc-examples to use optimization. 

pdf sectioning in evince is weird, and I don't know why 