### PR TITLE
make elisp-bytecode.pdf depend on all *.texi files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ clean: mostlyclean
 	rm -f $(DVI_TARGETS) $(HTML_TARGETS) $(PDF_TARGETS) $(PS_TARGETS)
 
 
-elisp-bytecode.pdf: $(TOP_SRC)
+elisp-bytecode.pdf: $(TOP_SRC) $(srcs)
 	$(ENVADD) $(TEXI2PDF) $<
 
 clean:


### PR DESCRIPTION
This fixes some build problems (or non-build problems, where elisp-bytecode.pdf didn't update after files were changed) for me.