### PR TITLE
Go over stack-manipulation instructions

### DIFF
--- a/instructions.texi
+++ b/instructions.texi
@@ -10,7 +10,6 @@
 * Control-Flow Instructions::
 * Function-Call Instructions::
 * Stack-Manipulation Instructions::
-* Binding Instructions::
 * Unused Instructions::
 @end menu
 
@@ -213,30 +212,27 @@ A stack index
 @item Added in:
 Emacs 24.1. @xref{Emacs 24}.
 @item Example:
-When lexical binding is in effect,
+When lexical binding and optimization are in effect,
 @verbatim
 (defun stack-ref-eg()
   (let ((a 5) (_b 6) (c 7))
     (+ a c)))}
 @end verbatim
 generates:
-@c ((lexical . t) (optimize . nil))
+@c ((lexical . t) (optimize . t))
 @verbatim
 PC  Byte  Instruction
- 0  192   constant[0] 5
- 1  193   constant[1] 6
- 2  194   constant[2] 7
- 3    2   stack-ref[2]  ;; top++; TOS <- S[3]
- 4    1   stack-ref[1]  ;; top++; TOS <- S[2]
+ 0  192   constant[0] 5 ;; top++; TOS <- 5
+ 1  193   constant[1] 6 ;; top++; TOS <- 6
+ 2  194   constant[2] 7 ;; top++; TOS <- 7
+ 3    2   stack-ref[2]  ;; top++; TOS <- S[3] (5)
+ 4    1   stack-ref[1]  ;; top++; TOS <- S[2] (7)
  5   92   plus
- 6  178   stack-set [3] ;; Set return value, S[2]
-          3             ;; before discarding stack entries
- 8  136   discard
- 9  136   discard
-10  135   return
+ 6  135   return
 
 Constants Vector: [5 6 7]
 @end verbatim
+
 @end table
 
 @strong{Warning}
@@ -308,7 +304,7 @@ A constants vector index. The constants vector item should be a variable symbol.
 @item Example:
 When dynamic binding is in effect,
 @verbatim
-defun varset(n)
+defun varset-eg(n)
   (setq n 5))
 @end verbatim
 generates:
@@ -403,11 +399,13 @@ stack. This is done when the variable is no longer needed.
 @table @strong
 @item Implements:
 @code{(set_internal(constants_vector[i])}
+@item Generated via:
+@code{let} in dynamic binding. Balancing the end of @code{save-excursion}.
 @item Instruction size:
 1 byte for @code{varset[0]} .. @code{varset[4]}; 2 bytes for @code{varset[5]},
 8-bit operand; 3 bytes for @code{varset[6]}, 16-bit operand.
 @item Stack effect:
-@math{-0+1}.
+@math{-0+0}.
 @item Example:
 When dynamic binding is in effect,
 @verbatim
@@ -1612,7 +1610,8 @@ instructions for the case where there are 1 to 4 items in the list.
 
 @table @strong
 @item Implements:
-@code{S[n-1] <- (list S[n-1] S[n-2] ... TOS); top -= (n-1)}.
+@code{S[n-1] <- (list S[n-1] S[n-2] ... TOS); top -= (n-1)} where @code{n}
+is the value of the operand.
 @item Generated via:
 @code{list}.
 @item Operand:
@@ -3465,6 +3464,7 @@ simply call the corresponding C function.
 
 @menu
 * char-syntax::
+* save-excursion::
 * set-marker::
 * match-beginning::
 * match-end::
@@ -3499,11 +3499,43 @@ Constants Vector: [97]
 
 @end table
 
+@SubSecInstruction{save-excursion, 138}
+
+Make a binding recording buffer, point, and mark.
+
+This instruction manipulates the special-bindings stack by creating a
+new binding when executed.  It needs to be balanced with
+@code{unbind} instructions.
+
+@table @strong
+@item Implements:
+@code{(save-excursion)}.
+@item Generated via:
+@code{save-excursion}
+@item Instruction size:
+1 byte
+@item Stack effect:
+@math{-0+0}.
+@item Example:
+When lexical binding is in effect,
+@code{(defun save-excursion-eg() (save-excursion 1380))} generates:
+@c ((lexical . t) (optimize . nil))
+@verbatim
+PC  Byte  Instruction
+ 0  138   save-excursion
+ 1  192   constant[0] 1380
+ 2   41   unbind[1]
+ 3  135   return
+
+Constants Vector: [1380]
+@end verbatim
+
+@end table
+
+
 @SubSubSecInstruction{set-marker, 147}
 
 Call @code{set-marker} with three stack arguments.
-
-Call @code{set-marker}.
 
 @table @strong
 @item Implements:
@@ -3566,7 +3598,7 @@ Constants Vector: [1]
 
 @SubSubSecInstruction{match-end, 149}
 
-Call @code{match-end} with one argument.
+Call @code{match-end} with one stack argument.
 
 @table @strong
 @item Implements:
@@ -3608,53 +3640,178 @@ Constants Vector: [1]
 
 Discard one value from the stack.
 
+@kindex discard
+@table @strong
+@item Implements:
+@code{top--}
+@item Instruction size:
+1 byte
+@item Generated via:
+Function calls that do not use the returned value; the end of @code{let} forms
+in lexical binding to remove locally-bound variables.
+@item Stack effect:
+@math{-1+0}.
+@item Example:
+@code{(defun discard-eg() (exchange-point-and-mark) (point))} generates:
+@verbatim
+PC  Byte  Instruction
+ 0  192   constant[0] exchange-point-and-mark
+ 1   32   call[0]
+ 2  136   discard
+ 3   96   point
+ 4  135   return
+
+Constants Vector: [exchange-point-and-mark]
+@end verbatim
+
+@end table
+
 @SubSecInstruction{discardN, 180}
 
-Discards up to 255 arguments from the stack.  Note there is a special
+Discards up to 127 arguments from the stack.  Note there is a special
 instruction when there is only one argument.
 
-Added in Emacs 24.1
+@kindex discardN
+@table @strong
+@item Implements:
+@code{if (n & 8) S[n] <- TOS; top -= n & 7;  } where @code{n} where @code{n}
+is the value of the operand.
+@item operand:
+7-bit number of items to discard. The top 8th bit when set indicates to keep
+the old TOS value after discarding.
+@item Instruction size:
+2 bytes
+@item Generated via:
+Function calls that do not use the returned value; the end of @code{let} forms
+in lexical binding with optimization to remove locally-bound variables.
+@item Stack effect:
+@math{-n+0}
+@item Added in:
+Emacs 24.1. @xref{Emacs 24}.
+@item Example:
+When lexical binding is in effect and optimization are in effect,
+@verbatim{(defun discardN-eg()
+  (1+ (let ((a 1) (_b) (_c)) a)))
+@end verbatim
+generates:
+@c ((lexical . t) (optimize . t))
+@verbatim
+PC  Byte  Instruction
+ 0  192   constant[0] 1
+ 1  193   constant[1] nil
+ 2  137   dup
+ 3    2   stack-ref[2]
+ 4  182   discardN [131]
+         131
+ 6   84   add1
+ 7  135   return
+
+Constants Vector: [1 nil]
+@end verbatim
+
+@end table
 
 @SubSecInstruction{dup, 137}
 
 Make a copy of the top-of-stack value and push that onto the top of the evaluation stack.
 
-@subsubsection Example
-When lexical binding is in effect, @code{(defun en(n) n)} generates:
+@table @strong
+@item Implements:
+@code{top++; TOS <- S[1]}
+
+@item Generated via:
+@code{setq} in dynamic bindings to set a value and then use it. In lexical binding, to use the
+first argument parameter.
+@item Instruction size:
+1 byte
+@item Stack effect:
+@math{-0+1}.
+@item Example:
+When lexical binding is in effect,
+@verbatim{(defun dup-eg(n) n)
+@end verbatim
+generates:
 @c ((lexical . t) (optimize . nil))
 @verbatim
 PC  Byte  Instruction
- 0  137   dup  ;; duplicates top of stack: n
+ 0  137   dup  ;; duplicates top of stack, argument n
  1  135   return
 @end verbatim
 
-@SubSecInstruction{stack-set, 180}
+@end table
 
-Like discard. [What's the difference?]
+@SubSecInstruction{stack-set, 178}
 
-Added in Emacs 24.1
+Sets a value on the evaluation stack to TOS.
 
-@SubSecInstruction{stack-set2, 181}
+@table @strong
+@item Implements:
+@code{S[i] <- TOS; top--} where @code{i} is the value of the
+instruction operand.
 
-Like discardN. [What's the difference?]
-Can handle up to 255 stack arguments.  Note there is a special
-instruction when there is only one argument.
+Note that @code{stack-set[0]} has the same effect as @code{discard},
+but does a little more work to do this.  @code{stack-set[1]} has the same
+effect as @code{discardN 1} with the top bit of @code{discardN} set to
+preserve @code{TOS}.
 
-Added in Emacs 24.1
+@item Generated via:
+@code{let}, @code{let*} and lambda arguments.
+@item Operand:
+A 8-bit integer stack index
+@item Instruction size:
+2 bytes
+@item Stack effect:
+@math{-1+0}.
+@item Added in:
+Emacs 24.1. @xref{Emacs 24}.
+@item Example:
+When lexical binding is in effect and optimization
+@verbatim
+defun stack-set-eg()
+(let ((a 5) a)))
+@end verbatim
+generates:
+@c ((lexical . t) (optimize . t))
+@verbatim
+PC  Byte  Instruction
+ 0  192   constant[0] 5
+ 1  193   constant[1] nil
+ 2  193   constant[1] nil
+ 3  178   stack-set [2]
+           2
+ 5  136   discard
+ 6  135   return
 
-@SECTION{Binding Instructions}
+Constants Vector: [5 nil]
+@end verbatim
 
-These instructions manipulate the special-bindings stack by creating a
-new binding when executed.  They need to be balanced with
-@code{unbind} instructions.
+@end table
 
-@menu
-* save-excursion::
-@end menu
+@SubSecInstruction{stack-set2, 179}
 
-@FirstSubSecInstruction{save-excursion, 138}
+@table @strong
+@item Implements:
+@code{S[i] <- TOS; top--} where @code{i} is the value of the
+instruction operand.
 
-Make a binding recording buffer, point, and mark.
+Note that @code{stack-set2[0]} has the same effect as @code{discard},
+but does a little more work to do this.  @code{stack-set2[1]} has the same
+effect as @code{discardN 1} with the top bit of @code{discardN} set to
+preserve @code{TOS}.
+
+@item Generated via:
+@code{let}, @code{let*} and lambda arguments.
+@item Operand:
+A 16-bit integer stack index
+@item Instruction size:
+3 bytes
+@item Stack effect:
+@math{-1+0}.
+@item Added in:
+Emacs 24.1. @xref{Emacs 24}.
+@item Example:
+??
+@end table
 
 @SECTION{Unused Instructions}
 

--- a/instructions.texi
+++ b/instructions.texi
@@ -3499,7 +3499,7 @@ Constants Vector: [97]
 
 @end table
 
-@SubSecInstruction{save-excursion, 138}
+@SubSubSecInstruction{save-excursion, 138}
 
 Make a binding recording buffer, point, and mark.
 

--- a/macros.texi
+++ b/macros.texi
@@ -47,7 +47,7 @@
 
 @macro SubSubSecInstruction{name, opcode}
 @page
-@majorheading \name\
+@majorheading \name\ (\opcode\)
 @node \name\
 @unnumberedsubsubsec @code{\name\} (\opcode\)
 @kindex \name\

--- a/opcode-table.texi
+++ b/opcode-table.texi
@@ -957,18 +957,20 @@ and for a description of how to interpret the stack-effect field.
 @tab @verb{|  stack-set|}
 @tab 1
 @tab @xref{stack-set}.
+@tab @math{-1}
 @item @verb{|0263|}
 @tab @verb{| 179|}
 @tab @verb{|  stack-set2|}
 @tab 1
 @tab @xref{stack-set2}.
+@tab @math{-1}
 
 @item @verb{|0222|}
 @tab @verb{|*146|}
 @tab @verb{| *unbind-all|}
 @tab 1
 @tab @xref{unbind-all}.
-@tab @math{-0+0}
+@tab @math{-0}
 
 @item @verb{|0223|}
 @tab @verb{| 147|}
@@ -1180,7 +1182,7 @@ and for a description of how to interpret the stack-effect field.
 @tab @verb{|  discardN|}
 @tab 1
 @tab @xref{discardN}.
-@tab @math{-n+1}
+@tab @math{-n+0}
 @item @verb{|0267|}
 @tab @verb{| 183|}
 @tab @verb{|  switch|}


### PR DESCRIPTION
@pipcet I don't understand how the stack-set example works. Perhaps the Lisp code just does something different than I expect. Also don't know forcing a stack-set2 example seems a bit tedious if we have to have something like 255 parameters. 