### PR TITLE
Fix a typo and add an appendix name so the .info file builds without error.

### DIFF
--- a/indices.texi
+++ b/indices.texi
@@ -1,5 +1,5 @@
 @node Indices
-@appendix
+@appendix Indices
 
 @menu
 * References::

--- a/instructions.texi
+++ b/instructions.texi
@@ -4464,8 +4464,9 @@ in lexical binding with optimization to remove locally-bound variables.
 Emacs 24.1. @xref{Emacs 24}.
 @item Example:
 When lexical binding is in effect and optimization are in effect,
-@verbatim{(defun discardN-eg()
-  (1+ (let ((a 1) (_b) (_c)) a))
+@verbatim
+(defun discardN-eg()
+  (1+ (let ((a 1) (_b) (_c)) a)))
 @end verbatim
 generates:
 @c ((lexical . t) (optimize . t))


### PR DESCRIPTION
When I tried to build the .info file these two errors prevented it from building.  With these changes it builds without an error.