### PR TITLE
Document `pushcatch` and correct bytecode counts and lengths

### DIFF
--- a/instructions.texi
+++ b/instructions.texi
@@ -281,8 +281,8 @@ dynamic variable access
 @item Operand:
 A constants vector index. The constants vector item should be a variable symbol.
 @item Instruction size:
-1 byte for @code{varref[0]} .. @code{varref[4]}; 2 bytes for @code{varref[5]},
-8-bit operand; 3 bytes for @code{varref[6]}, 16-bit operand.
+1 byte for @code{varref[0]} .. @code{varref[5]}; 2 bytes for @code{varref[6]},
+8-bit operand; 3 bytes for @code{varref[7]}, 16-bit operand.
 @item Stack effect:
 @math{-0+1}.
 @item Type Information:
@@ -317,8 +317,8 @@ of the stack.
 @item Operand:
 A constants vector index. The constants vector item should be a variable symbol.
 @item Instruction size:
-1 byte for @code{varset[0]} .. @code{varset[4]}; 2 bytes for @code{varset[5]},
-8-bit operand; 3 bytes for @code{varset[6]}, 16-bit operand.
+1 byte for @code{varset[0]} .. @code{varset[5]}; 2 bytes for @code{varset[6]},
+8-bit operand; 3 bytes for @code{varset[7]}, 16-bit operand.
 @item Stack effect:
 @math{-1+0}.
 @item Type Information:
@@ -352,8 +352,8 @@ symbol to a special-bindings stack.
 @item Implements:
 @code{*constants[OPERAND]<-TOS; top--}
 @item Instruction size:
-1 byte for @code{varbind[0]} .. @code{varbind[4]}; 2 bytes for @code{varbind[5]},
-8-bit operand; 3 bytes for @code{varbind[6]}, 16-bit operand.
+1 byte for @code{varbind[0]} .. @code{varbind[5]}; 2 bytes for @code{varbind[6]},
+8-bit operand; 3 bytes for @code{varbind[7]}, 16-bit operand.
 @item Stack effect:
 @math{-1+0}.
 @item Type Information:
@@ -460,8 +460,8 @@ undo's a @code{let}, @code{unwind-protect}s, and @code{save-excursion}s
 @item Generated via:
 @code{let} in dynamic binding. Balancing the end of @code{save-excursion}.
 @item Instruction size:
-1 byte for @code{unbind[0]} .. @code{unbind[4]}; 2 bytes for @code{unbind[5]},
-8-bit operand; 3 bytes for @code{unbind[6]}, 16-bit operand.
+1 byte for @code{unbind[0]} .. @code{unbind[5]}; 2 bytes for @code{unbind[6]},
+8-bit operand; 3 bytes for @code{unbind[7]}, 16-bit operand.
 @item Stack effect:
 @math{-0+0}.
 @item Example:

--- a/instructions.texi
+++ b/instructions.texi
@@ -649,9 +649,13 @@ Constants Vector: [(another-error) (one-error) 5 6 7]
 
 @table @strong
 @item Implements:
-Pops the TOS which is some sort of condition to test on and
-registers that. If any of the instructions errors with that condition,
-a jump to the operand occurs.
+Pops the TOS which is some sort of condition to test on, registers that
+and remembers the stack position @code{S_top}. If any of the
+instructions errors with that condition, the stack is restored to
+@code{S_top}, an error value of the form @code{(ERROR-SYMBOL .
+SIGNAL-DATA)} is pushed onto the stack and a jump to the operand occurs.
+@item Generated via:
+@code{condition-case}
 @item Operand:
 16-bit PC address
 @item Instruction size:
@@ -697,8 +701,45 @@ Constants Vector: [(another-error) (one-error) 5 6 7]
 
 @SubSecInstruction{pushcatch, 50}
 
-?
+@table @strong
+@item Implements:
+Pops the TOS which is a tag used by nonlocal exits, registers that. and
+remembers the stack position @code{S_top}. If any of the instructions
+throws with that tag, the stack is restored to @code{S_top}, the thrown
+value is pushed onto the stack and a jump to the operand occurs.
+@item Generated via:
+@code{catch}
+@item Operand:
+16-bit PC address
+@item Instruction size:
+3 bytes
+@item Stack effect:
+@math{-1+0}.
+@item Added in:
+Emacs 24.4. @xref{Emacs 24}.
+@item Example:
+@verbatim
+(defun pushcatch-eg()
+  (catch 'break
+    (throw 'break 42)))
+@end verbatim
+generates:
+@verbatim
+PC  Byte  Instruction
+ 0  192   constant[0] break
+ 1   50   pushcatch [9]
+           9
+           0
+ 4  193   constant[1] throw
+ 5  192   constant[0] break
+ 6  194   constant[2] 42
+ 7   34   call[2]
+ 8   48   pophandler
+ 9  135   return
 
+Constants Vector: [break throw 42]
+@end verbatim
+@end table
 
 @SECTION{Control-Flow Instructions}
 
@@ -4614,6 +4655,7 @@ generates these instructions.
 * set-mark::
 * interactive-p::
 * save-window-excursion::
+* catch::
 * condition-case::
 * temp-output-buffer-setup::
 * temp-output-buffer-show::
@@ -4673,6 +4715,26 @@ PC  Byte  Instruction
 
 Constants Vector: [(1390)]
 @end verbatim
+@end table
+
+@FirstSubSecInstruction{catch, 141}
+
+Replaced by @code{pushcatch}. @xref{pushcatch}
+
+@table @strong
+@item Implements:
+Pops the TOS which is a tag used by nonlocal exits, pops the TOS again
+and evaluates it. If the evaluated form throws with that tag, the thrown
+value is pushed onto the stack.
+@item Generated via:
+?
+@item Instruction size:
+1 byte
+@item Stack effect:
+@math{-2+1}.
+@item Obsolete since:
+Emacs 24.4. @xref{Emacs 24}.
+
 @end table
 
 @FirstSubSecInstruction{condition-case, 143}

--- a/opcode-table.texi
+++ b/opcode-table.texi
@@ -896,11 +896,15 @@ and for a description of how to interpret the stack-effect field.
 @tab @verb{| 140|}
 @tab @tab @tab Unused
 @item @verb{|0215|}
-@tab @verb{| 141|}
-@tab @tab @tab Unused
+@tab @verb{|*141|}
+@tab @verb{| *catch|}
+@tab 1
+@tab @xref{catch}
+@tab @math{-2+1}
 @item @verb{|0216|}
 @tab @verb{| 142|}
 @tab @verb{| unwind-protect|}
+@tab 1
 @tab @xref{unwind-protect}.
 @tab @math{-1+0}
 @item @verb{|0217|}

--- a/opcode-table.texi
+++ b/opcode-table.texi
@@ -324,20 +324,20 @@ and for a description of how to interpret the stack-effect field.
 @tab @verb{|  48|}
 @tab @verb{|  pophandler|}
 @tab 1
-@tab
+@tab @xref{pophandler}
 @tab @math{-0}
 @item @verb{| 061|}
 @tab @verb{|  49|}
-@tab @verb{|  conditioncase|}
+@tab @verb{|  pushconditioncase|}
 @tab 3
-@tab
-@tab @math{-1+\phi(0,+1)}
+@tab @xref{pushconditioncase}
+@tab @math{-1+0}
 @item @verb{| 062|}
 @tab @verb{|  50|}
-@tab @verb{|  pushconditioncase|}
-@tab 1
-@tab
-@tab @math{-0}
+@tab @verb{|  pushcatch|}
+@tab 3
+@tab @xref{pushcatch}
+@tab @math{-1+0}
 
 @item @verb{| 063|}
 @tab @verb{|  51|}
@@ -825,39 +825,39 @@ and for a description of how to interpret the stack-effect field.
 @item @verb{|0201|}
 @tab @verb{| 129|}
 @tab @verb{|  constant2|}
-@tab 1
+@tab 3
 @tab @xref{constant2}.
 @tab @math{+1}
 @item @verb{|0202|}
 @tab @verb{| 130|}
 @tab @verb{|  goto|}
-@tab 1
+@tab 3
 @tab @xref{goto}.
 @tab @math{-0+0}
 @item @verb{|0203|}
 @tab @verb{| 131|}
 @tab @verb{|  goto-if-nil|}
-@tab 1
+@tab 3
 @tab @xref{goto-if-nil}.
 @tab @math{-1+0}
 @item @verb{|0204|}
 @tab @verb{| 132|}
 @tab @verb{|  goto-if-not-nil|}
-@tab 1
+@tab 3
 @tab @xref{goto-if-not-nil}.
 @tab @math{-1+0}
 @item @verb{|0205|}
 @tab @verb{| 133|}
 @tab @verb{|  goto-if-nil-
  else-pop|}
-@tab 1
+@tab 3
 @tab @xref{goto-if-nil-else-pop}.
 @tab @math{\phi(-1,0)+0}
 @item @verb{|0206|}
 @tab @verb{| 134|}
 @tab @verb{|  goto-if-not-
  nil-else-pop|}
-@tab 1
+@tab 3
 @tab @xref{goto-if-not-nil-else-pop}.
 @tab @math{\phi(-1,0)+0}
 @item @verb{|0207|}
@@ -926,48 +926,6 @@ and for a description of how to interpret the stack-effect field.
 @tab 1
 @tab @xref{temp-output-buffer-show}.
 @tab @math{-0+0}
-
-@item @verb{|0222|}
-@tab @verb{| 146|}
-@tab @tab @tab Unused
-@item @verb{|0223|}
-@tab @verb{| 147|}
-@tab @tab @tab Unused
-
-@item @verb{|0256|}
-@tab @verb{| 174|}
-@tab @tab @tab Unused
-
-@item @verb{|0257|}
-@tab @verb{| 175|}
-@tab @verb{|  listN|}
-@tab 2
-@tab @xref{listN}.
-@tab @math{-n+1}
-@item @verb{|0260|}
-@tab @verb{| 176|}
-@tab @verb{|  concatN|}
-@tab 2
-@tab @xref{concatN}.
-@tab @math{-n+1}
-@item @verb{|0261|}
-@tab @verb{| 177|}
-@tab @verb{|  insertN|}
-@tab 2
-@tab @xref{insertN}.
-@tab @math{-n+1}
-@item @verb{|0262|}
-@tab @verb{| 178|}
-@tab @verb{|  stack-set|}
-@tab 1
-@tab @xref{stack-set}.
-@tab @math{-1}
-@item @verb{|0263|}
-@tab @verb{| 179|}
-@tab @verb{|  stack-set2|}
-@tab 1
-@tab @xref{stack-set2}.
-@tab @math{-1}
 
 @item @verb{|0222|}
 @tab @verb{|*146|}
@@ -1154,25 +1112,26 @@ and for a description of how to interpret the stack-effect field.
 @tab @verb{|  concatN|}
 @tab 2
 @tab @xref{concatN}.
+@tab @math{-n+1}
 @item @verb{|0261|}
 @tab @verb{| 177|}
 @tab @verb{|  insertN|}
-@tab 1
+@tab 2
 @tab @xref{insertN}.
 @tab @math{-n+1}
 
 @item @verb{|0262|}
 @tab @verb{| 178|}
 @tab @verb{|  stack-set|}
-@tab 1
+@tab 2
 @tab @xref{stack-set}.
-@tab @math{-0+0}
+@tab @math{-1+0}
 @item @verb{|0263|}
 @tab @verb{| 179|}
 @tab @verb{|  stack-set2|}
-@tab 2
+@tab 3
 @tab @xref{stack-set2}.
-@tab @math{-0+0}
+@tab @math{-1+0}
 
 @item @verb{|0264|}
 @tab @verb{| 180|}
@@ -1184,7 +1143,7 @@ and for a description of how to interpret the stack-effect field.
 @item @verb{|0266|}
 @tab @verb{| 182|}
 @tab @verb{|  discardN|}
-@tab 1
+@tab 2
 @tab @xref{discardN}.
 @tab @math{-n+0}
 @item @verb{|0267|}


### PR DESCRIPTION
Hello! I added some documentation for `pushcatch` and `catch`. This PR also corrects some bytecode counts and lengths and removes some seemingly misplaced/duplicate lines:

https://github.com/rocky/elisp-bytecode/blob/787cd36494b191faba18448aab223061418c7323/opcode-table.texi#L926-L966